### PR TITLE
Fix local gateway for single thread server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to `laravel-redsys` will be documented in this file.
 
 ## 3.0.0 - 2024-06-02
 
+- New: Local gateway is refactored to work with Sail, `artisan serve` or any other single threaded server.
 - New: Improved REST integration with handled responses.
 - Breaking: Updated database schema to allow different transaction types (refunds for example) with the same order number.
 

--- a/src/Controllers/RedsysLocalGatewayController.php
+++ b/src/Controllers/RedsysLocalGatewayController.php
@@ -33,8 +33,13 @@ class RedsysLocalGatewayController
         );
 
         if (isset($params['DS_MERCHANT_MERCHANTURL'])) {
-            Http::withoutVerifying()
-                ->post($params['DS_MERCHANT_MERCHANTURL'], $fakeGateway->getResponse($request->responseCode));
+            // https://stackoverflow.com/questions/61703814/guzzle-cannot-send-a-web-request-to-the-same-server
+            $request = Request::create(
+                $params['DS_MERCHANT_MERCHANTURL'],
+                'POST',
+                $fakeGateway->getResponse($request->responseCode)
+            );
+            app()->handle($request);
         }
 
         return $authorised
@@ -53,7 +58,13 @@ class RedsysLocalGatewayController
         );
 
         if (isset($params['DS_MERCHANT_MERCHANTURL'])) {
-            Http::post($params['DS_MERCHANT_MERCHANTURL'], $fakeGateway->getResponse($request->responseCode));
+            // https://stackoverflow.com/questions/61703814/guzzle-cannot-send-a-web-request-to-the-same-server
+            $request = Request::create(
+                $params['DS_MERCHANT_MERCHANTURL'],
+                'POST',
+                $fakeGateway->getResponse($request->responseCode)
+            );
+            app()->handle($request);
         }
 
         return response()->json();

--- a/src/Controllers/RedsysLocalGatewayController.php
+++ b/src/Controllers/RedsysLocalGatewayController.php
@@ -4,7 +4,6 @@ namespace Creagia\LaravelRedsys\Controllers;
 
 use Creagia\Redsys\RedsysResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Http;
 
 class RedsysLocalGatewayController
 {


### PR DESCRIPTION
This PR fixes the local gateway for single threaded servers like Sail or the `php artisan serve` command.

With this change, the same request will handle the notfication request instead of sending a new POST http request from the existing request.

This PR should fix these issues https://github.com/creagia/laravel-redsys/issues/38 https://github.com/creagia/laravel-redsys/issues/35 https://github.com/creagia/laravel-redsys/issues/29 https://github.com/creagia/laravel-redsys/issues/8 https://github.com/creagia/laravel-redsys/issues/30